### PR TITLE
Fix organization create

### DIFF
--- a/src/components/Dashboard/index.jsx
+++ b/src/components/Dashboard/index.jsx
@@ -226,8 +226,7 @@ const Dashboard = ({ background = "white", textColor = "black" }) => {
       if (showOrgForm) {
         validateHandle(
           checkOrgHandleExists,
-          firebase,
-          dispatch,
+          firestore,
           orgHandle,
           setOrgHandleValidateError,
           setOrgHandleValidateErrorMessage,

--- a/src/store/actions/authActions.js
+++ b/src/store/actions/authActions.js
@@ -210,7 +210,6 @@ export const checkOrgHandleExists = orgHandle => async firestore => {
       .doc(orgHandle)
       .get();
 
-    console.log(organizationHandle);
     return organizationHandle.exists;
   } catch (e) {
     throw e.message;
@@ -244,8 +243,9 @@ export const setUpInitialData =
       }
 
       if (orgData) {
-        const isOrgHandleExists =
-          await checkOrgHandleExists(org_handle)(firestore);
+        const isOrgHandleExists = await checkOrgHandleExists(org_handle)(
+          firestore
+        );
 
         if (isOrgHandleExists) {
           dispatch({
@@ -270,11 +270,14 @@ export const setUpInitialData =
         );
 
         // Create organisation handle
-        await firestore.collection("org_users").doc(`${org_handle}_${userData.uid}`).set({
-          uid: userData.uid,
-          org_handle: org_handle,
-          permissions: [3]
-        });
+        await firestore
+          .collection("org_users")
+          .doc(`${org_handle}_${userData.uid}`)
+          .set({
+            uid: userData.uid,
+            org_handle: org_handle,
+            permissions: [3]
+          });
 
         const timeOutID = setTimeout(() => {
           firebase


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The arguments to check for validation of Organization inputs were incorrect. Instead of `firestore` firebase object was passed and also an extra dispatch argument was passed, which caused the orgHandle value to be `dispatch` rather than string.

<!--- Describe your changes in detail -->

## Related Issue
Fixes #2 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
New Users should be able to create organizations, else only the default organizations would be present.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Created several new users along with organizations to test correctly.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots or GIF (In case of UI changes):

https://github.com/user-attachments/assets/12b37228-2e71-475d-890a-a7f37a1c8a39


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
